### PR TITLE
Updated OpenMRS_Platform to 1.11.2 from 1.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD run.sh /root/run.sh
 
 RUN apt-get update; \
   apt-get install -y curl openjdk-7-jre tomcat7; \
-  curl -L http://sourceforge.net/projects/openmrs/files/releases/OpenMRS_Platform_1.10.1/openmrs.war/download \
+  curl -L http://sourceforge.net/projects/openmrs/files/releases/OpenMRS_Platform_1.11.2/openmrs.war/download \
        -o /var/lib/tomcat7/webapps/openmrs.war; \
   apt-get install -y mysql-server; \
   mkdir /var/lib/OpenMRS; \


### PR DESCRIPTION
Hi Burke,

I'm updating the OpenMRS_Platform to the latest version in the Dockerfile. This allows us to deploy OpenMRS 2.2 to Docker.

Sincerely,
Craig
